### PR TITLE
Update utils.py

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1,10 +1,67 @@
 import pandas as pd
 import numpy as np
+from numba import njit, prange
+from typing import Union, List
 
 
-def get_kelly(returns, window=400, r=0.02, correlation=False):
-    """Gets Kelly optimal investment fraction
+@njit(cache=True)
+def get_kelly_numba(
+    cov_arr: np.ndarray[float], returns: np.ndarray[float]
+) -> np.ndarray[float]:
+    """Compute kelly values using numba for speed
+
+    Args:
+        cov_arr (np.ndarray[float]): array of covariances without NaNs
+        returns (np.ndarray[float]): array of returns without NaNs
+
+    Returns:
+        np.ndarray[float]: array of kelly values
+    """
+    ret_covars = np.empty_like(cov_arr)
+    kelly = np.empty_like(returns)
+    for i in prange(cov_arr.shape[0]):
+        # Use copies to avoid issues with non-contiguous arrays
+        inv_cov = np.linalg.inv(cov_arr[i])
+        ret_day = returns[i].copy() 
+        ret_covars[i] = inv_cov 
+        kelly[i] = np.dot(inv_cov, ret_day)
+    return kelly
+
+
+def get_kelly_wrap(cov_arr: pd.DataFrame, returns: pd.DataFrame) -> pd.DataFrame:
+    """Wrapper around numba function to build kelly DataFrame
+
+    Args:
+        cov_arr (pd.DataFrame): DataFrame of covariances
+        returns (pd.DataFrame): DataFrame of excess returns
+
+    Returns:
+        pd.DataFrame: Kelly values
+    """
+   
+    # Get dimensions to reshape the array
+    dim0 = len(cov_arr.index.get_level_values(0).unique())
+    dim1 = len(cov_arr.index.get_level_values(1).unique())
+    dim3 = cov_arr.shape[1]
     
+    # Get array of kelly values
+    kelly = get_kelly_numba(
+        cov_arr.values.reshape(dim0, dim1, dim3), returns.values
+    )
+    
+    # Return DataFrame
+    return pd.DataFrame(kelly, columns=returns.columns, index=returns.index)
+
+
+def get_kelly(
+    returns: Union[pd.DataFrame, pd.Series],
+    window: int = 400,
+    r: float = 0.02,
+    correlation=False,
+    days: int = 250,
+) -> pd.DataFrame:
+    """Gets Kelly optimal investment fraction
+
     Parameters
     ----------
     returns : pd.DataFrame or pd.Series
@@ -12,78 +69,76 @@ def get_kelly(returns, window=400, r=0.02, correlation=False):
     window : int, optional
         Minimum periods to calculate the parameters. Default 400.
     r : int, optional
-        Risk-free yearly returns. Example: Treasury bills. Default 0.02. 
+        Risk-free yearly returns. Example: Treasury bills. Default 0.02.
     correlation : bool, optional
-        If a portfolio of securities is given, indicate whether the 
-        securities are correlationated or not.      
-        
+        If a portfolio of securities is given, indicate whether the
+        securities are correlationated or not.
+    days : int, optional
+        Number of days to use. Default 250
+
     Returns
     -------
     kelly : pd.DataFrame
         Frame containing the corresponding kelly values for each security
     """
-    days = 250
     r_adjusted = (1 + r) ** (1 / days) - 1
-    mean = returns.expanding(window).mean()
+    mean = returns.expanding(window).mean().dropna()
     return_exces = mean - r_adjusted
 
     if correlation:
-        roll_cov = returns.expanding(400).cov()
-        roll_inv_cov = roll_cov.copy()
-        kelly = pd.DataFrame(columns=mean.columns) 
-
-        for day in returns.index:
-            roll_inv_cov.loc[day] = np.linalg.inv(roll_cov.loc[day])
-            kelly.loc[day] = np.dot(roll_inv_cov.loc[day], return_exces.loc[day])
-            
+        roll_cov = returns.expanding(window).cov().dropna()
+        kelly = get_kelly_wrap(roll_cov, return_exces)
     else:
-        var = returns.expanding(window).var()
+        var = returns.expanding(window).var().dropna()
         kelly = return_exces / var
-    
-    kelly = kelly.dropna()
-    
+
     return kelly
 
 
-def filter_leverage(serie, leverage):
+def filter_leverage(serie: pd.Series, leverage: int) -> pd.Series:
     """filters leverage
-    
+
     Parameters
     ----------
     serie : pd.Series
     leverage : int
-    
+
     Returns
     -------
     filtered_serie : pd.Series
     """
-    
+
     filtered_serie = serie.copy()
-    filtered_serie[filtered_serie>leverage] = leverage
-    
+    filtered_serie[filtered_serie > leverage] = leverage
+
     return filtered_serie
 
 
-def get_cumulative_returns(returns):
+def get_cumulative_returns(
+    returns: Union[pd.Series, pd.DataFrame]
+) -> Union[pd.Series, pd.DataFrame]:
     """Gets cumulative returns
-    
+
     Parameters
     ----------
     returns : pd.Series, pd.DataFrame
-    
+
     Returns
-    ------- 
+    -------
     cum_returns : pd.Series, pd.DataFrame
     """
-    
+
     cum_returns = (1 + returns).cumprod()
     cum_returns = cum_returns.dropna()
-    
+
     return cum_returns
 
-def backtest(kelly_df, returns_df, leverages):
+
+def backtest(
+    kelly_df: pd.DataFrame, returns_df: pd.DataFrame, leverages: List[int]
+) -> pd.DataFrame:
     """Backtests Kelly strategy
-    
+
     Parameters
     ----------
     kelly_df : pd.DataFrame
@@ -92,26 +147,28 @@ def backtest(kelly_df, returns_df, leverages):
         daily returns of the securities
     leverages : list
         list containing the number of leverages to study
-        
+
     Returns
     -------
     total_returns : pd.DataFrame
     """
-    
+
     total_returns = pd.DataFrame()
 
     for leverage in leverages:
         kelly_weights = kelly_df.copy()
 
         # restrict shortselling
-        kelly_weights[kelly_weights<0] = 0
+        kelly_weights[kelly_weights < 0] = 0
 
         daily_weights_sum = kelly_weights.sum(axis=1)
         leverage_cond = daily_weights_sum > leverage
 
-        kelly_weights[leverage_cond] = leverage * kelly_weights[leverage_cond].div(daily_weights_sum[leverage_cond], axis=0)
+        kelly_weights[leverage_cond] = leverage * kelly_weights[leverage_cond].div(
+            daily_weights_sum[leverage_cond], axis=0
+        )
 
-        name = 'max_leverage_' + str(leverage) 
+        name = "max_leverage_" + str(leverage)
         total_returns[name] = (returns_df * kelly_weights).sum(axis=1)
-        
+
     return total_returns


### PR DESCRIPTION
Added a `numba` function to speed up correlation computations (158 ms vs 8.34 s on my machine  ≈ 53X)  and a wrapper function to prepare the data.  
Fixed the hard-coded value in covariance (should be window, not 400). 
Dropped the NaNs at the origin. Numba complains if there are NaNs.

Added type hints for python 3.9. 
Requires numba.
I have checked the results, and they match.
```
from utils import get_kelly as gk
opt_correlated_kelly2 = gk(returns_df, correlation=True)
np.allclose(opt_correlated_kelly2.values, opt_correlated_kelly.values)
```
Result: 
```
True
```
Performance:
```
%%timeit
get_kelly(returns_df, correlation=True)
```
Result:
```
158 ms ± 1.93 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
Original version:
```
%%timeit
gk(returns_df, correlation=True)
```
Result:
```
8.32 s ± 25.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
**Around 53X.**

I suppose that `leverages` in `backtest` should be a `list` of `int` but can be converted into a `list` of `float` if needed.

My setup:
- numpy 1.23.5
- numba 0.57,1
-  pandas 2.0.3
- python 3.9.15
- matplotlib 3.7.2
- seaborn 0.12.2

Notebook (I renamed `utils.py` to `utils2.py` locally to test it):
[The Kelly Criterion-Copy1.pdf](https://github.com/adalseno/The-Kelly-Criterion/files/12339773/The.Kelly.Criterion-Copy1.pdf)

Thank you very much for your code.